### PR TITLE
Bump versions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:5-apache
+FROM php:7-apache
 MAINTAINER Fabian Köster <mail@fabian-koester.com>
 
 EXPOSE 80
@@ -6,10 +6,14 @@ EXPOSE 80
 ARG DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && apt-get install -y --no-install-recommends \
     unzip \
+    zlib1g-dev \
  && rm -rf /var/lib/apt/lists/*
 
-ARG KIMAI_VERSION=1.1.0
-ARG KIMAI_SHA256=3484b3f30f95b5866cf3dfa1e52bbff5ef85f19da9f9620f6458a26b8cc30e81
+RUN docker-php-ext-install mysqli
+RUN docker-php-ext-install zip
+
+ARG KIMAI_VERSION=1.3.1
+ARG KIMAI_SHA256=cbf86e8e52bc48a1769e15301463b698f475c47201c973268c43a38efc3491ad
 
 RUN curl -L -o kimai.zip https://github.com/kimai/kimai/releases/download/${KIMAI_VERSION}/kimai_${KIMAI_VERSION}.zip \
   && echo "${KIMAI_SHA256} kimai.zip" | sha256sum -c \
@@ -18,4 +22,3 @@ RUN curl -L -o kimai.zip https://github.com/kimai/kimai/releases/download/${KIMA
   && chown -R www-data:www-data /var/www/html/ \
   && rm *.zip
 
-RUN docker-php-ext-install mysqli

--- a/README.md
+++ b/README.md
@@ -44,3 +44,13 @@ docker-compose exec kimai rm -rf /var/www/html/installer
 Create a file `.env` in the working directory with any of the following variables:
 
 * `EXTERNAL_PORT`: The external port (and ip address) to bind to (default `127.0.0.1:8080`)
+
+## Upgrading Kimai
+
+In the [Dockerfile](Dockerfile), bump `KIMAI_VERSION` and the `KIMAI_SHA256`.
+
+Build the new image
+
+    docker build -t  maestroalubia/kimai .
+
+Restart docker-compose.


### PR DESCRIPTION
Use PHP-7 and Kimai 1.3.1.

Extend README on how to build a new image.